### PR TITLE
feat!: Do not filter commits by defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Most changes are optionals and configurable.
 # Installation
 
 ```
-$ deno install -A -f --no-check -n release_up https://deno.land/x/release_up@0.6.0/cli.ts
+$ deno install -A -f -n release_up https://deno.land/x/release_up@0.6.0/cli.ts
 ```
 
 # Usage

--- a/plugins/changelog/mod.ts
+++ b/plugins/changelog/mod.ts
@@ -3,7 +3,7 @@ import { join } from "./deps.ts";
 import type { ReleasePlugin } from "../../plugin.ts";
 import {
   Document,
-  filters,
+  defaultFilters,
   polyfillVersion,
   pushHeader,
   pushTag,
@@ -29,12 +29,8 @@ const plugin: ReleasePlugin = {
       const tag = tags[i];
       const parent = i < tags.length - 1 ? tags[i + 1] : undefined;
       const belonging = commits.filter((_) => _.belongs?.hash === tag.hash);
-      const filteredTypes = filters.map((f) => f.type);
-      const filteredCommits = belonging.filter((_) =>
-        filteredTypes.includes(_.cc.type || "")
-      );
-      if (filteredCommits.length) {
-        pushTag(doc, repo, belonging, filters, tag, "md", parent);
+      if (belonging.length) {
+        pushTag(doc, repo, belonging, defaultFilters, tag, "md", parent);
       }
     }
 

--- a/plugins/changelog/mod.ts
+++ b/plugins/changelog/mod.ts
@@ -2,12 +2,12 @@ import { join } from "./deps.ts";
 
 import type { ReleasePlugin } from "../../plugin.ts";
 import {
-  significantCommits,
   Document,
   polyfillVersion,
   pushHeader,
   pushTag,
   render,
+  significantCommits,
 } from "../../src/changelog.ts";
 
 const plugin: ReleasePlugin = {

--- a/plugins/changelog/mod.ts
+++ b/plugins/changelog/mod.ts
@@ -2,8 +2,8 @@ import { join } from "./deps.ts";
 
 import type { ReleasePlugin } from "../../plugin.ts";
 import {
-  Document,
   defaultFilters,
+  Document,
   polyfillVersion,
   pushHeader,
   pushTag,

--- a/plugins/changelog/mod.ts
+++ b/plugins/changelog/mod.ts
@@ -2,7 +2,7 @@ import { join } from "./deps.ts";
 
 import type { ReleasePlugin } from "../../plugin.ts";
 import {
-  defaultFilters,
+  significantCommits,
   Document,
   polyfillVersion,
   pushHeader,
@@ -30,7 +30,7 @@ const plugin: ReleasePlugin = {
       const parent = i < tags.length - 1 ? tags[i + 1] : undefined;
       const belonging = commits.filter((_) => _.belongs?.hash === tag.hash);
       if (belonging.length) {
-        pushTag(doc, repo, belonging, defaultFilters, tag, "md", parent);
+        pushTag(doc, repo, belonging, significantCommits, tag, "md", parent);
       }
     }
 

--- a/plugins/github/mod.ts
+++ b/plugins/github/mod.ts
@@ -1,7 +1,7 @@
 import { ReleasePlugin } from "../../plugin.ts";
 import {
-  Document,
   defaultFilters,
+  Document,
   polyfillVersion,
   pushTag,
   render,

--- a/plugins/github/mod.ts
+++ b/plugins/github/mod.ts
@@ -1,6 +1,6 @@
 import { ReleasePlugin } from "../../plugin.ts";
 import {
-  defaultFilters,
+  significantCommits,
   Document,
   polyfillVersion,
   pushTag,
@@ -53,7 +53,7 @@ const plugin: ReleasePlugin<GithubConfig> = {
     const latest = tags[0];
     const belonging = commits.filter((_) => _.belongs?.hash === latest.hash);
     const parent = tags.length > 0 ? tags[1] : undefined;
-    pushTag(doc, repo, belonging, defaultFilters, latest, "github", parent);
+    pushTag(doc, repo, belonging, significantCommits, latest, "github", parent);
 
     if (!config.options.dry) {
       const token = Deno.env.get(GITHUB_TOKEN)!;

--- a/plugins/github/mod.ts
+++ b/plugins/github/mod.ts
@@ -1,10 +1,10 @@
 import { ReleasePlugin } from "../../plugin.ts";
 import {
-  significantCommits,
   Document,
   polyfillVersion,
   pushTag,
   render,
+  significantCommits,
 } from "../../src/changelog.ts";
 
 import * as gh from "./api.ts";

--- a/plugins/github/mod.ts
+++ b/plugins/github/mod.ts
@@ -1,7 +1,7 @@
 import { ReleasePlugin } from "../../plugin.ts";
 import {
   Document,
-  filters,
+  defaultFilters,
   polyfillVersion,
   pushTag,
   render,
@@ -53,7 +53,7 @@ const plugin: ReleasePlugin<GithubConfig> = {
     const latest = tags[0];
     const belonging = commits.filter((_) => _.belongs?.hash === latest.hash);
     const parent = tags.length > 0 ? tags[1] : undefined;
-    pushTag(doc, repo, belonging, filters, latest, "github", parent);
+    pushTag(doc, repo, belonging, defaultFilters, latest, "github", parent);
 
     if (!config.options.dry) {
       const token = Deno.env.get(GITHUB_TOKEN)!;

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -18,7 +18,7 @@ export const significantCommits: Filter[] = [
   {
     type: "fix",
     title: "Bug Fixes",
-  }
+  },
 ];
 
 export interface Document {
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.`);
 /**
  * Push a list of commits in the section with a title
  * @param title tile of the section in the document
- * @param style Style formatting of the document. Github releases have links different from the changelog  
+ * @param style Style formatting of the document. Github releases have links different from the changelog
  */
 export function pushChanges(
   doc: Document,
@@ -96,32 +96,39 @@ export function pushTag(
     doc.sections.push(`## ${tag.version} - ${year}-${month}-${day}`);
   }
 
-  const breaking: Commit[] = [] 
-  const sections: { [key: string]: Commit[] } = {}
-  const others: Commit[] = []
+  const breaking: Commit[] = [];
+  const sections: { [key: string]: Commit[] } = {};
+  const others: Commit[] = [];
 
   let hasConventionalCommit = false;
   for (const commit of commits) {
-    const type = commit.cc.type
+    const type = commit.cc.type;
     if (type && commit.cc.header?.includes(`!:`)) {
-      breaking.push(commit)
-      hasConventionalCommit = true
-    } else if (type && significantCommits.map(t => t.type).includes(type)) {
-      if (!sections[type]) sections[type] = []
-      sections[type].push(commit)
-      hasConventionalCommit = true
+      breaking.push(commit);
+      hasConventionalCommit = true;
+    } else if (type && significantCommits.map((t) => t.type).includes(type)) {
+      if (!sections[type]) sections[type] = [];
+      sections[type].push(commit);
+      hasConventionalCommit = true;
     } else {
-      others.push(commit)
+      others.push(commit);
     }
   }
 
-  if (breaking.length) pushChanges(doc, repo, 'Breaking', breaking, style);
+  if (breaking.length) pushChanges(doc, repo, "Breaking", breaking, style);
   for (const significantCommit of significantCommits) {
-    if(sections[significantCommit.type]?.length) pushChanges(doc, repo, significantCommit.title, sections[significantCommit.type], style);
+    if (sections[significantCommit.type]?.length) {
+      pushChanges(
+        doc,
+        repo,
+        significantCommit.title,
+        sections[significantCommit.type],
+        style,
+      );
+    }
   }
-  const othersTitle = hasConventionalCommit ? 'Others' : ''
+  const othersTitle = hasConventionalCommit ? "Others" : "";
   if (others.length) pushChanges(doc, repo, othersTitle, others, style);
-  
 
   if (repo.remote && repo.remote.github && parent) {
     const linkName = `${parent.version}...${tag.version}`;

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -75,7 +75,6 @@ export function pushTag(
   doc: Document,
   repo: Repo,
   commits: Commit[],
-
   // TODO: remove this parameter
   _filters: Filter[],
   tag: Tag,

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -54,7 +54,7 @@ export function pushChanges(
   commits: Commit[],
   style: "github" | "md",
 ): void {
-  if (title !== '') doc.sections.push(`### ${title}`);
+  if (title !== "") doc.sections.push(`### ${title}`);
   const list: string[] = [];
   for (const commit of commits) {
     const { hash } = commit;
@@ -104,18 +104,18 @@ export function pushTag(
   let hasConventionalCommit = false;
   // capture all commits by their types
   for (const filter of filters) {
-    let title = filter.title
+    let title = filter.title;
     let filtered;
-    if (filter.type === '!') {
+    if (filter.type === "!") {
       // process breaking change
-      filtered = commits.filter((commit) => commit.cc.type?.endsWith('!'));
-      if (filtered.length > 0) hasConventionalCommit = true
+      filtered = commits.filter((commit) => commit.cc.type?.endsWith("!"));
+      if (filtered.length > 0) hasConventionalCommit = true;
     } else if (filter.type !== "") {
       // use conventional commmits as defined in filters
       filtered = commits.filter((commit) =>
         commit.cc.type?.toLocaleLowerCase() === filter.type.toLocaleLowerCase()
       );
-      if (filtered.length > 0) hasConventionalCommit = true
+      if (filtered.length > 0) hasConventionalCommit = true;
     } else {
       // capture other commits
       const types = filters.map((f) => f.type);
@@ -125,7 +125,7 @@ export function pushTag(
     }
     if (filtered.length > 0) {
       if (!hasConventionalCommit) {
-        title = '' 
+        title = "";
       }
       pushChanges(doc, repo, title, filtered, style);
     }

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -75,7 +75,9 @@ export function pushTag(
   doc: Document,
   repo: Repo,
   commits: Commit[],
-  filters: Filter[],
+
+  // TODO: remove this parameter
+  _filters: Filter[],
   tag: Tag,
   style: "github" | "md",
   parent?: Tag,

--- a/src/commits.ts
+++ b/src/commits.ts
@@ -45,7 +45,10 @@ export async function fetchRawCommits(
       const author = details[2];
 
       const body = `${title}\n${description}`;
-      const cc = ccparse(body);
+      const cc = ccparse(body, {
+        // Allow for ! after the scope
+        headerPattern: new RegExp(/^(\w*)(?:\(([\w\$\.\-\* ]*)\))?(?:\:|!\:) (.*)$/)
+      });
 
       return {
         hash,

--- a/src/commits.ts
+++ b/src/commits.ts
@@ -47,7 +47,9 @@ export async function fetchRawCommits(
       const body = `${title}\n${description}`;
       const cc = ccparse(body, {
         // Allow for ! after the scope
-        headerPattern: new RegExp(/^(\w*)(?:\(([\w\$\.\-\* ]*)\))?(?:\:|!\:) (.*)$/)
+        headerPattern: new RegExp(
+          /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?(?:\:|!\:) (.*)$/,
+        ),
       });
 
       return {


### PR DESCRIPTION
Previously the tool was filtering non conventional commits by defaults. This has 2 problems:
- Not everyone follow conventional commits
- Not everyone follow the same list.

I have remove the filtering by default. If the commit type is inferred correctly, feat and fix and breaking will be extracted.

I have also added support for breaking changes with `!`